### PR TITLE
Use Static<typeof BlockEvent> to avoid TS errors

### DIFF
--- a/backend/lib/deal-observer.js
+++ b/backend/lib/deal-observer.js
@@ -1,5 +1,7 @@
 /** @import {Queryable} from '@filecoin-station/deal-observer-db' */
 /** @import { BlockEvent } from './rpc-service/data-types.js' */
+/** @import { Static } from '@sinclair/typebox' */
+
 import assert from 'node:assert'
 import { getActorEvents, getActorEventsFilter } from './rpc-service/service.js'
 import { ActiveDealDbEntry } from '@filecoin-station/deal-observer-db/lib/types.js'
@@ -30,7 +32,7 @@ export async function fetchDealWithHighestActivatedEpoch (pgPool) {
 }
 
 /**
- * @param {BlockEvent[]} activeDeals
+ * @param {Static<typeof BlockEvent>[]} activeDeals
  * @param {Queryable} pgPool
  * @returns {Promise<void>}
  * */

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -5,7 +5,7 @@ import { rawEventEntriesToEvent } from './utils.js'
 import { Value } from '@sinclair/typebox/value'
 import { ClaimEvent, RawActorEvent, BlockEvent, RpcRespone } from './data-types.js'
 
-/** @import {CID} from 'multiformats' */
+/** @import { Static } from '@sinclair/typebox' */
 
 /**
  * @param {string} method
@@ -25,7 +25,7 @@ export const rpcRequest = async (method, params) => {
 /**
  * @param {object} actorEventFilter
  * Returns actor events filtered by the given actorEventFilter
- * @returns {Promise<Array<BlockEvent>>}
+ * @returns {Promise<Array<Static<typeof BlockEvent>>>}
  */
 export async function getActorEvents (actorEventFilter, makeRpcRequest) {
   const rawEvents = await makeRpcRequest('Filecoin.GetActorEventsRaw', [actorEventFilter])

--- a/backend/test/deal-observer.test.js
+++ b/backend/test/deal-observer.test.js
@@ -36,7 +36,6 @@ describe('deal-observer-backend', () => {
     }
     const event = Value.Parse(BlockEvent, { height: 1, event: eventData, emitter: 'f06' })
 
-    // @ts-ignore
     await storeActiveDeals([event], pgPool)
     const result = await pgPool.query('SELECT * FROM active_deals')
     const expectedData = {
@@ -69,7 +68,6 @@ describe('deal-observer-backend', () => {
     }
     const event = Value.Parse(BlockEvent, { height: 1, event: eventData, emitter: 'f06' })
 
-    // @ts-ignore
     await storeActiveDeals([event], pgPool)
     const expected = Value.Parse(ActiveDealDbEntry, (await pgPool.query('SELECT * FROM active_deals')).rows[0])
     const actual = await fetchDealWithHighestActivatedEpoch(pgPool)


### PR DESCRIPTION
Fix types to remove the need for `// @ts-ignore`.

We should refactor the code to hide all typebox-related complexity inside the data-type files, including the code to parse JSON into typed values, but let's leave that as a follow-up task after we land the initial implementation.
