### PR TITLE
fix: remove zondax api

### DIFF
--- a/backend/lib/config.js
+++ b/backend/lib/config.js
@@ -1,5 +1,5 @@
 const {
-  RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.zondax.ch/fil/node/mainnet/rpc/v1',
+  RPC_URLS = 'https://api.node.glif.io/rpc/v0',
   GLIF_TOKEN
 } = process.env
 


### PR DESCRIPTION
This PR removes the zondax RPC api URL. 
We currently do not have an API key for this API and thus cannot say whether we can make the number of calls necessary to keep the database for active deals up to date with the filecoin blockchain. 

See the relevant discussion [here](https://github.com/filecoin-station/deal-observer/pull/29#discussion_r1931760447). 