### PR TITLE
fix: added logging to rpc request

### DIFF
--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -25,7 +25,7 @@ export const rpcRequest = async (method, params) => {
     }
     return Value.Parse(RpcRespone, await response.json()).result
   } catch (error) {
-    error.message = `Failed to make RPC request ${method}: ${error.message})`
+    error.message = `Failed to make RPC request ${method}: ${error.message}`
     throw error
   }
 }

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -25,7 +25,7 @@ export const rpcRequest = async (method, params) => {
     }
     return Value.Parse(RpcRespone, (await response.json())).result
   } catch (error) {
-    error.message = `Failed to make RPC request: ${error.message})`
+    error.message = `Failed to make RPC request ${method}: ${error.message})`
     throw error
   }
 }

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -21,7 +21,7 @@ export const rpcRequest = async (method, params) => {
       body: reqBody
     })
     if (!response.ok) {
-      throw new Error(`Fetch failed - HTTP ${response.status}: ${await response.text()}`)
+      throw new Error(`Fetch failed - HTTP ${response.status}: ${await response.text().catch(() => null)}`)
     }
     return Value.Parse(RpcRespone, await response.json()).result
   } catch (error) {

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -14,13 +14,20 @@ import { ClaimEvent, RawActorEvent, BlockEvent, RpcRespone } from './data-types.
  */
 export const rpcRequest = async (method, params) => {
   const reqBody = JSON.stringify({ method, params, id: 1, jsonrpc: '2.0' })
-  const response = await fetch(RPC_URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: reqBody
-  })
-
-  return Value.Parse(RpcRespone, (await response.json())).result
+  try {
+    const response = await fetch(RPC_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: reqBody
+    })
+    if (!response.ok) {
+      throw new Error(`Fetch failed - HTTP ${response.status}: ${await response.text()}`)
+    }
+    return Value.Parse(RpcRespone, (await response.json())).result
+  } catch (error) {
+    error.message = `Failed to make RPC request: ${error.message})`
+    throw error
+  }
 }
 /**
  * @param {object} actorEventFilter

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -23,7 +23,7 @@ export const rpcRequest = async (method, params) => {
     if (!response.ok) {
       throw new Error(`Fetch failed - HTTP ${response.status}: ${await response.text()}`)
     }
-    return Value.Parse(RpcRespone, (await response.json())).result
+    return Value.Parse(RpcRespone, await response.json()).result
   } catch (error) {
     error.message = `Failed to make RPC request ${method}: ${error.message})`
     throw error


### PR DESCRIPTION
This PR introduces the following changes: 

1. Handle non 200 responses from the RPC endpoint
2. Add better error messages upon a failed fetch method

See the relevant discussion [here](https://github.com/filecoin-station/deal-observer/pull/29#discussion_r1932075473). 