### PR TITLE
fix: add pretry to rpc requests

### DIFF
--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -4,7 +4,7 @@ import { encode as cborEncode } from '@ipld/dag-cbor'
 import { rawEventEntriesToEvent } from './utils.js'
 import { Value } from '@sinclair/typebox/value'
 import { ClaimEvent, RawActorEvent, BlockEvent, RpcRespone } from './data-types.js'
-
+import pRetry from 'p-retry'
 /** @import { Static } from '@sinclair/typebox' */
 
 /**
@@ -14,11 +14,12 @@ import { ClaimEvent, RawActorEvent, BlockEvent, RpcRespone } from './data-types.
  */
 export const rpcRequest = async (method, params) => {
   const reqBody = JSON.stringify({ method, params, id: 1, jsonrpc: '2.0' })
-  const response = await fetch(RPC_URL, {
+
+  const response = await pRetry(async () => await fetch(RPC_URL, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: reqBody
-  })
+  }), { retries: 5 })
 
   return Value.Parse(RpcRespone, (await response.json())).result
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@sinclair/typebox": "^0.34.14",
     "debug": "^4.4.0",
     "multiformats": "^13.3.1",
+    "p-retry": "^6.2.1",
     "pg": "^8.13.1",
     "slug": "^10.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@sinclair/typebox": "^0.34.14",
         "debug": "^4.4.0",
         "multiformats": "^13.3.1",
+        "p-retry": "^6.2.1",
         "pg": "^8.13.1",
         "slug": "^10.0.0"
       },
@@ -1289,6 +1290,12 @@
       "dependencies": {
         "@types/pg": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "license": "MIT"
     },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
@@ -3605,6 +3612,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -4342,6 +4361,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -5055,6 +5091,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {


### PR DESCRIPTION
This PR adds the pretry package to the deal-observer backend. 
The use of this package should account for networking issues when making the request by retrying the request a few times before giving up. 