### PR TITLE
fix:  lastInsertedDeal wrong field

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -31,7 +31,7 @@ const dealObserverLoop = async (makeRpcRequest, pgPool) => {
       const currentFinalizedChainHead = currentChainHead.Height - finalityEpochs
       // If the storage is empty we start 2000 blocks into the past as that is the furthest we can go with the public glif rpc endpoints.
       const lastInsertedDeal = await fetchDealWithHighestActivatedEpoch(pgPool)
-      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.height : currentChainHead.Height - maxPastEpochs
+      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentChainHead.Height - maxPastEpochs
       for (let epoch = lastEpochStored + 1; epoch <= currentFinalizedChainHead; epoch++) {
         await observeBuiltinActorEvents(epoch, pgPool, makeRpcRequest)
       }

--- a/backend/lib/deal-observer.js
+++ b/backend/lib/deal-observer.js
@@ -23,7 +23,7 @@ export async function observeBuiltinActorEvents (blockHeight, pgPool, makeRpcReq
 
 /**
  * @param {Queryable} pgPool
- * @returns {Promise<ActiveDealDbEntry | null>}
+ * @returns {Promise<Static<typeof ActiveDealDbEntry> | null>}
  */
 export async function fetchDealWithHighestActivatedEpoch (pgPool) {
   const query = 'SELECT * FROM active_deals ORDER BY activated_at_epoch DESC LIMIT 1'
@@ -103,7 +103,7 @@ export async function storeActiveDeals (activeDeals, pgPool) {
 /**
  * @param {Queryable} pgPool
  * @param {string} query
- * @returns {Promise<Array<ActiveDealDbEntry>>}
+ * @returns {Promise<Array<Static<typeof ActiveDealDbEntry>>>}
  */
 async function loadDeals (pgPool, query) {
   const result = (await pgPool.query(query)).rows.map(deal => {


### PR DESCRIPTION
This PR fixes the issue of calling the wrong field name for the last inserted deal. 
A deal contains the field `activated_at_epoch` while the BlockEvent contains the field `height`. 